### PR TITLE
Fixed object name in documentation (CDN part)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const balance = await tonweb.getBalance("EQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bp
 <script src="https://cdn.jsdelivr.net/gh/toncenter/tonweb/dist/tonweb.js"></script>
 <script>
     document.addEventListener("DOMContentLoaded", function () {
-        TonAccess.getHttpEndpoint().then((endpoint) => { // get the decentralized RPC endpoint
+        TonGateway.getHttpEndpoint().then((endpoint) => { // get the decentralized RPC endpoint
             const tonweb = new TonWeb(new TonWeb.HttpProvider(endpoint)); // initialize tonweb library
             // make some query to mainnet
             tonweb.getBalance("EQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8xqB2N").then((balance) => {


### PR DESCRIPTION
The exported object is called `TonGateway`, not `TonAccess`
```javascript
...
var nt = T((C) => {
        Object.defineProperty(C, "__esModule", { value: !0 });
        var j = L();
        // here
        window.TonGateway = { create: () => new j.Gateway(), getHttpEndpoint: j.getHttpEndpoint, getHttpV4Endpoint: j.getHttpV4Endpoint };
    });
    nt();
```
After loading the script via CDN, `TonGateway` needs to be referenced, not `TonAccess`. Otherwise, the call to, e.g.,  TonAccess.getHttpEndpoint will cause "not defined" error. I propose to fix that in the docs.
```javascript
TonAccess.getHttpEndpoint() // TonAccess is not defined
TonGateway.getHttpEndpoint() // this works
```